### PR TITLE
🧹 [code health improvement] Remove unused import AIProviderInfo in useAnimationLogic

### DIFF
--- a/frontend/src/contexts/animation/useAnimationLogic.ts
+++ b/frontend/src/contexts/animation/useAnimationLogic.ts
@@ -5,7 +5,7 @@ import { AnimationContextType, Message, ChatData } from '../../types/animation';
 import { AnimationApi, AnimationStorageApi, AnimationGenerateResult } from '../../services/api';
 import { AnimationRegistryHelpers } from '../../hooks/useAnimationLoader';
 import { useViewerPreferences } from '../ViewerPreferencesContext';
-import { AIProviderId, AIProviderInfo } from '@/types/ai';
+import { AIProviderId } from '@/types/ai';
 import { normalizeProviderId, buildProviderSelection } from '@/utils/providerUtils';
 import { exportAnimation as exportAnimationUtil, canExportAsSvg as canExportAsSvgUtil } from '../../utils/exportUtils';
 import { isMobileDevice, isFreshPageLoad } from '../../utils/deviceUtils';


### PR DESCRIPTION
🎯 **What:** Removed the unused import `AIProviderInfo` from `frontend/src/contexts/animation/useAnimationLogic.ts`.
💡 **Why:** Removing unused imports improves code readability and maintainability by reducing noise.
✅ **Verification:**
- Manually verified that `AIProviderInfo` was not used anywhere in the file.
- Verified that `AIProviderId` is still being used and was correctly kept in the import.
✨ **Result:** Cleaned up the import section of `useAnimationLogic.ts`.

---
*PR created automatically by Jules for task [15527643829915493652](https://jules.google.com/task/15527643829915493652) started by @goggledefogger*